### PR TITLE
Update docker/build-push-action

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -11,7 +11,7 @@ jobs:
           uses: actions/checkout@v2
 
       -   name: Push to GitHub Packages
-          uses: docker/build-push-action@v1
+          uses: docker/build-push-action@v2
           with:
             username: ${{ github.actor }}
             password: ${{ github.token }}


### PR DESCRIPTION
Update version for `docker/build-push-action` image. 

`docker/build-push-action@v1` is deprecated
